### PR TITLE
Pull #1: simplest generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,35 @@
+# Eclipse project files
+.settings
+.externalToolBuilders
+.classpath
+.project
+
+# m2e-code-quality Eclipse IDE plugin temporary configuration files for Eclipse CS Checkstyle / PMD / FindBugs Plug-Ins
+.checkstyle
+.pmd
+.pmdruleset.xml
+.fbExcludeFilterFile
+
+# NetBeans project files
+nbactions.xml
+nb-configuration.xml
+
+# Maven build folder
+target
+bin
+
+# IDEA project files
+regression-tool.iml
+regression-tool.ipr
+regression-tool.iws
+.idea
+
+# Temp files
+*~
+
+# Java Virtual machine crash logs
+hs_err_pid*
+replay_pid*
+
+# Apple MacOS hidden file
+.DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+language: java
+
+sudo: false
+
+install:
+  -
+
+addons:
+  apt:
+    packages:
+      - oracle-java8-installer
+
+cache:
+  directories:
+    - ~/.m2
+
+branches:
+  only:
+    - master
+
+matrix:
+  fast_finish: true
+  include:
+    - jdk: oraclejdk8
+      env:
+        - DESC="mvn clean verify"
+        - CMD="mvn clean verify"
+
+script: eval $CMD
+
+after_success:
+  -

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,502 @@
+                  GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 2.1, February 1999
+
+ Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+     59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+[This is the first released version of the Lesser GPL.  It also counts
+ as the successor of the GNU Library Public License, version 2, hence
+ the version number 2.1.]
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+Licenses are intended to guarantee your freedom to share and change
+free software--to make sure the software is free for all its users.
+
+  This license, the Lesser General Public License, applies to some
+specially designated software packages--typically libraries--of the
+Free Software Foundation and other authors who decide to use it.  You
+can use it too, but we suggest you first think carefully about whether
+this license or the ordinary General Public License is the better
+strategy to use in any particular case, based on the explanations below.
+
+  When we speak of free software, we are referring to freedom of use,
+not price.  Our General Public Licenses are designed to make sure that
+you have the freedom to distribute copies of free software (and charge
+for this service if you wish); that you receive source code or can get
+it if you want it; that you can change the software and use pieces of
+it in new free programs; and that you are informed that you can do
+these things.
+
+  To protect your rights, we need to make restrictions that forbid
+distributors to deny you these rights or to ask you to surrender these
+rights.  These restrictions translate to certain responsibilities for
+you if you distribute copies of the library or if you modify it.
+
+  For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you.  You must make sure that they, too, receive or can get the source
+code.  If you link other code with the library, you must provide
+complete object files to the recipients, so that they can relink them
+with the library after making changes to the library and recompiling
+it.  And you must show them these terms so they know their rights.
+
+  We protect your rights with a two-step method: (1) we copyright the
+library, and (2) we offer you this license, which gives you legal
+permission to copy, distribute and/or modify the library.
+
+  To protect each distributor, we want to make it very clear that
+there is no warranty for the free library.  Also, if the library is
+modified by someone else and passed on, the recipients should know
+that what they have is not the original version, so that the original
+author's reputation will not be affected by problems that might be
+introduced by others.
+
+  Finally, software patents pose a constant threat to the existence of
+any free program.  We wish to make sure that a company cannot
+effectively restrict the users of a free program by obtaining a
+restrictive license from a patent holder.  Therefore, we insist that
+any patent license obtained for a version of the library must be
+consistent with the full freedom of use specified in this license.
+
+  Most GNU software, including some libraries, is covered by the
+ordinary GNU General Public License.  This license, the GNU Lesser
+General Public License, applies to certain designated libraries, and
+is quite different from the ordinary General Public License.  We use
+this license for certain libraries in order to permit linking those
+libraries into non-free programs.
+
+  When a program is linked with a library, whether statically or using
+a shared library, the combination of the two is legally speaking a
+combined work, a derivative of the original library.  The ordinary
+General Public License therefore permits such linking only if the
+entire combination fits its criteria of freedom.  The Lesser General
+Public License permits more lax criteria for linking other code with
+the library.
+
+  We call this license the "Lesser" General Public License because it
+does Less to protect the user's freedom than the ordinary General
+Public License.  It also provides other free software developers Less
+of an advantage over competing non-free programs.  These disadvantages
+are the reason we use the ordinary General Public License for many
+libraries.  However, the Lesser license provides advantages in certain
+special circumstances.
+
+  For example, on rare occasions, there may be a special need to
+encourage the widest possible use of a certain library, so that it becomes
+a de-facto standard.  To achieve this, non-free programs must be
+allowed to use the library.  A more frequent case is that a free
+library does the same job as widely used non-free libraries.  In this
+case, there is little to gain by limiting the free library to free
+software only, so we use the Lesser General Public License.
+
+  In other cases, permission to use a particular library in non-free
+programs enables a greater number of people to use a large body of
+free software.  For example, permission to use the GNU C Library in
+non-free programs enables many more people to use the whole GNU
+operating system, as well as its variant, the GNU/Linux operating
+system.
+
+  Although the Lesser General Public License is Less protective of the
+users' freedom, it does ensure that the user of a program that is
+linked with the Library has the freedom and the wherewithal to run
+that program using a modified version of the Library.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.  Pay close attention to the difference between a
+"work based on the library" and a "work that uses the library".  The
+former contains code derived from the library, whereas the latter must
+be combined with the library in order to run.
+
+                  GNU LESSER GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License Agreement applies to any software library or other
+program which contains a notice placed by the copyright holder or
+other authorized party saying it may be distributed under the terms of
+this Lesser General Public License (also called "this License").
+Each licensee is addressed as "you".
+
+  A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+  The "Library", below, refers to any such software library or work
+which has been distributed under these terms.  A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+  "Source code" for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
+
+  Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+
+  1. You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+  You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+  2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+  Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+  This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+  4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+  If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library".  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+  However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library".  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+  When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+  If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+  Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+  6. As an exception to the Sections above, you may also combine or
+link a "work that uses the Library" with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer's own use and reverse
+engineering for debugging such modifications.
+
+  You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+
+    b) Use a suitable shared library mechanism for linking with the
+    Library.  A suitable mechanism is one that (1) uses at run time a
+    copy of the library already present on the user's computer system,
+    rather than copying library functions into the executable, and (2)
+    will operate properly with a modified version of the library, if
+    the user installs one, as long as the modified version is
+    interface-compatible with the version that the work was made with.
+
+    c) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
+
+    d) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
+
+    e) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+  For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the materials to be distributed need not include anything that is
+normally distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+  It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
+
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+  10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties with
+this License.
+
+  11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
+
+  13. The Free Software Foundation may publish revised and/or new
+versions of the Lesser General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+  14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+                            NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+           How to Apply These Terms to Your New Libraries
+
+  If you develop a new library, and you want it to be of the greatest
+possible use to the public, we recommend making it free software that
+everyone can redistribute and change.  You can do so by permitting
+redistribution under these terms (or, alternatively, under the terms of the
+ordinary General Public License).
+
+  To apply these terms, attach the following notices to the library.  It is
+safest to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least the
+"copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the library's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the library, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the
+  library `Frob' (a library for tweaking knobs) written by James Random Hacker.
+
+  <signature of Ty Coon>, 1 April 1990
+  Ty Coon, President of Vice
+
+That's all there is to it!

--- a/config/checkstyle.properties
+++ b/config/checkstyle.properties
@@ -1,0 +1,4 @@
+checkstyle.suppressions.file=config/suppressions.xml
+checkstyle.header.file=https://raw.githubusercontent.com/checkstyle/checkstyle/master/config/java.header
+checkstyle.regexp.header.file=https://raw.githubusercontent.com/checkstyle/checkstyle/master/config/java_regexp.header
+checkstyle.importcontrol.file=config/import-control.xml

--- a/config/import-control.xml
+++ b/config/import-control.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<!DOCTYPE import-control PUBLIC
+        "-//Puppy Crawl//DTD Import Control 1.1//EN"
+        "http://www.puppycrawl.com/dtds/import_control_1_1.dtd">
+
+<import-control pkg="com.github.checkstyle.regression">
+    <allow pkg="java.io"/>
+    <allow pkg="java.util"/>
+    <subpackage name="generator">
+        <allow pkg="javax.xml"/>
+        <allow pkg="org.w3c"/>
+        <allow pkg="org.xml"/>
+        <allow pkg="com.github.checkstyle.regression.git"/>
+        <allow class="com.puppycrawl.tools.checkstyle.utils.ModuleReflectionUtils"/>
+    </subpackage>
+    <subpackage name="git">
+        <allow pkg="org.eclipse.jgit"/>
+    </subpackage>
+</import-control>

--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<!DOCTYPE suppressions PUBLIC
+        "-//Puppy Crawl//DTD Suppressions 1.1//EN"
+        "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+
+<suppressions>
+</suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.github.checkstyle</groupId>
+    <artifactId>regression-tool</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <checkstyle.version>7.8.1</checkstyle.version>
+        <maven.plugin.checkstyle.version>2.17</maven.plugin.checkstyle.version>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-jxr</artifactId>
+            <version>2.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jgit</groupId>
+            <artifactId>org.eclipse.jgit</artifactId>
+            <version>4.8.0.201705170830-rc1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.puppycrawl.tools</groupId>
+            <artifactId>checkstyle</artifactId>
+            <version>${checkstyle.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>${maven.plugin.checkstyle.version}</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.puppycrawl.tools</groupId>
+                        <artifactId>checkstyle</artifactId>
+                        <version>${checkstyle.version}</version>
+                    </dependency>
+                </dependencies>
+                <executions>
+                    <execution>
+                        <id>check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <includeResources>false</includeResources>
+                            <includeTestResources>false</includeTestResources>
+                            <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                            <configLocation>
+                                https://raw.githubusercontent.com/checkstyle/checkstyle/checkstyle-${checkstyle.version}/config/checkstyle_checks.xml
+                            </configLocation>
+                            <propertiesLocation>config/checkstyle.properties</propertiesLocation>
+                            <failOnViolation>true</failOnViolation>
+                            <logViolationsToConsole>true</logViolationsToConsole>
+                            <maxAllowedViolations>0</maxAllowedViolations>
+                            <violationSeverity>error</violationSeverity>
+                            <outputFileFormat>xml</outputFileFormat>
+                            <outputFile>
+                                ${project.build.directory}/checkstyle/checkstyle-report.xml
+                            </outputFile>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/github/checkstyle/regression/Main.java
+++ b/src/main/java/com/github/checkstyle/regression/Main.java
@@ -1,0 +1,38 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2017 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.github.checkstyle.regression;
+
+/**
+ * Utility class, contains main function and its auxiliary routines.
+ * @author LuoLiangchen
+ */
+public final class Main {
+    /** Prevents instantiation. */
+    private Main() {
+    }
+
+    /**
+     * Executes CLI command.
+     * @param args the CLI arguments
+     * @throws Exception execute failure
+     */
+    public static void main(String[] args) throws Exception {
+    }
+}

--- a/src/main/java/com/github/checkstyle/regression/generator/AbstractConfigGenerator.java
+++ b/src/main/java/com/github/checkstyle/regression/generator/AbstractConfigGenerator.java
@@ -1,0 +1,191 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2017 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.github.checkstyle.regression.generator;
+
+import java.io.StringReader;
+import java.util.List;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerConfigurationException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
+import com.github.checkstyle.regression.git.DiffParser;
+import com.github.checkstyle.regression.git.GitChange;
+
+/**
+ * The base class for config generators.
+ * Contains the common initialization and generation logic.
+ * @author LuoLiangchen
+ */
+public abstract class AbstractConfigGenerator {
+    /** The name of a module element. */
+    static final String ELEMENT_MODULE = "module";
+
+    /** The attribute name of a module element. */
+    static final String ATTR_NAME = "name";
+
+    /** The "doctype-public" value of the config. */
+    private static final String DOCTYPE_PUBLIC =
+            "-//Puppy Crawl//DTD Check Configuration 1.3//EN";
+
+    /** The "doctype-system" value of the config. */
+    private static final String DOCTYPE_SYSTEM =
+            "http://www.puppycrawl.com/dtds/configuration_1_3.dtd";
+
+    /** The config template. */
+    private static final String BASE_CONFIG = ""
+            + "<?xml version=\"1.0\" standalone=\"yes\"?>"
+            + "<module name=\"Checker\">\n"
+            + "  <property name=\"charset\" value=\"UTF-8\"/>\n"
+            + "  <property name=\"severity\" value=\"warning\"/>\n"
+            + "  <property name=\"haltOnException\" value=\"false\"/>\n"
+            + "  <module name=\"BeforeExecutionExclusionFileFilter\">\n"
+            + "    <property name=\"fileNamePattern\" value=\"module\\-info\\.java$\" />\n"
+            + "  </module>\n"
+            + "\n"
+            + "  <module name=\"TreeWalker\"></module>\n"
+            + "</module>";
+
+    /** The config XML document. */
+    private static Document xmlDocument;
+
+    /** The XML transformer. */
+    private static Transformer xmlTransformer;
+
+    /** The path of checkstyle repository. */
+    private String repoPath;
+
+    /** The name of the branch to be compared with main code-base. */
+    private String branch;
+
+    static {
+        try {
+            xmlDocument = DocumentBuilderFactory.newInstance().newDocumentBuilder()
+                    .parse(new InputSource(new StringReader(BASE_CONFIG)));
+            xmlTransformer = createXmlTransformer();
+        }
+        // -@cs[IllegalCatch] remove this after finding out a proper way to log message
+        catch (Exception ignore) {
+            // ignore, to-do: show error msg
+        }
+    }
+
+    /**
+     * Sets the path of checkstyle repository.
+     * @param repoPath the path of checkstyle repository
+     */
+    final void setRepoPath(String repoPath) {
+        this.repoPath = repoPath;
+    }
+
+    /**
+     * Sets the name of the branch to be compared with main code-base.
+     * @param branch the name of the branch to be compared with main code-base
+     */
+    final void setBranch(String branch) {
+        this.branch = branch;
+    }
+
+    /**
+     * Creates a new {@code Transformer} instance and do initialization.
+     * @return a new {@code Transformer} instance
+     * @throws TransformerConfigurationException fails to instantiate the {@code Transformer}
+     */
+    private static Transformer createXmlTransformer() throws TransformerConfigurationException {
+        final Transformer transformer = TransformerFactory.newInstance().newTransformer();
+        transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+        transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
+        transformer.setOutputProperty(OutputKeys.DOCTYPE_PUBLIC, DOCTYPE_PUBLIC);
+        transformer.setOutputProperty(OutputKeys.DOCTYPE_SYSTEM, DOCTYPE_SYSTEM);
+        return transformer;
+    }
+
+    /**
+     * Generates the config XML.
+     */
+    public void generate() {
+        try {
+            final Node treeWalkerNode = getTreeWalkerModuleNode();
+            final List<GitChange> gitChanges = new DiffParser(repoPath).parse(branch);
+            gitChanges.removeIf(this::whetherToSkipChange);
+            createModuleElements(gitChanges).forEach(treeWalkerNode::appendChild);
+            // Currently the output is printed to System.out
+            // It should be exported to a file in the future
+            xmlTransformer.transform(new DOMSource(xmlDocument), new StreamResult(System.out));
+        }
+        // -@cs[IllegalCatch] remove this after finding out a proper way to log message
+        catch (Exception ex) {
+            // ignore, to-do: show error msg
+        }
+    }
+
+    /**
+     * Gets the "TreeWalker" element node of the config document.
+     * @return the "TreeWalker" element node
+     */
+    private static Node getTreeWalkerModuleNode() {
+        final NodeList nodeList = xmlDocument.getDocumentElement()
+                .getElementsByTagName(ELEMENT_MODULE);
+        Node returnValue = null;
+        for (int i = 0; i < nodeList.getLength(); ++i) {
+            final Node node = nodeList.item(i);
+            final Node nameAttr = node.getAttributes().getNamedItem(ATTR_NAME);
+            if (nameAttr != null && "TreeWalker".equals(nameAttr.getNodeValue())) {
+                returnValue = node;
+                break;
+            }
+        }
+        return returnValue;
+    }
+
+    /**
+     * Gets the config XML document.
+     * @return the config XML document
+     */
+    static Document getXmlDocument() {
+        return xmlDocument;
+    }
+
+    /**
+     * Creates checkstyle module elements from a list of {@code GitChange}.
+     * @param gitChanges the git changes to be processed
+     * @return the generated module elements
+     */
+    protected abstract List<Element> createModuleElements(List<GitChange> gitChanges);
+
+    /**
+     * Returns whether to skip the given change when generator processes the git changes.
+     * @param gitChange the git change to be judged
+     * @return true if the change would be skipped
+     */
+    protected boolean whetherToSkipChange(GitChange gitChange) {
+        return false;
+    }
+}

--- a/src/main/java/com/github/checkstyle/regression/generator/ConfigGeneratorFactory.java
+++ b/src/main/java/com/github/checkstyle/regression/generator/ConfigGeneratorFactory.java
@@ -1,0 +1,69 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2017 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.github.checkstyle.regression.generator;
+
+/**
+ * Defines a factory API that enables developers to obtain a
+ * generator that processes the git changes and generates config XML.
+ * @author LuoLiangchen
+ */
+public final class ConfigGeneratorFactory {
+    /** The path of checkstyle repository. */
+    private String repoPath;
+
+    /** The name of the branch to be compared with main code-base. */
+    private String branch;
+
+    /** Prevents instantiation. */
+    private ConfigGeneratorFactory() {
+    }
+
+    /**
+     * Gets a new instance of {@code ConfigGeneratorFactory}.
+     * @param repoPath the path of checkstyle repository
+     * @param branch the name of the branch to be compared with main code-base
+     * @return the new instance of {@code ConfigGeneratorFactory}
+     */
+    public static ConfigGeneratorFactory newInstance(String repoPath, String branch) {
+        final ConfigGeneratorFactory factory = new ConfigGeneratorFactory();
+        factory.repoPath = repoPath;
+        factory.branch = branch;
+        return factory;
+    }
+
+    /**
+     * Returns a new {@code DefaultConfigGenerator} instance.
+     * @return the new {@code DefaultConfigGenerator} instance
+     */
+    public AbstractConfigGenerator newDefaultConfigGenerator() {
+        final AbstractConfigGenerator generator = new DefaultConfigGenerator();
+        initializeGenerator(generator);
+        return generator;
+    }
+
+    /**
+     * Initializes the generator.
+     * @param generator the generator to be initialized.
+     */
+    private void initializeGenerator(AbstractConfigGenerator generator) {
+        generator.setRepoPath(repoPath);
+        generator.setBranch(branch);
+    }
+}

--- a/src/main/java/com/github/checkstyle/regression/generator/DefaultConfigGenerator.java
+++ b/src/main/java/com/github/checkstyle/regression/generator/DefaultConfigGenerator.java
@@ -1,0 +1,91 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2017 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.github.checkstyle.regression.generator;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.w3c.dom.Element;
+
+import com.github.checkstyle.regression.git.GitChange;
+import com.puppycrawl.tools.checkstyle.utils.ModuleReflectionUtils;
+
+/**
+ * The simplest generator implementation using only default options of checks.
+ * @author LuoLiangchen
+ */
+public class DefaultConfigGenerator extends AbstractConfigGenerator {
+    @Override
+    protected List<Element> createModuleElements(List<GitChange> gitChanges) {
+        return gitChanges.stream()
+                .map(this::createModuleElement)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Creates checkstyle module element from a {@code GitChange}.
+     * @param gitChange the git change to be processed
+     * @return the generated module element
+     */
+    private Element createModuleElement(GitChange gitChange) {
+        final Element module = getXmlDocument().createElement(ELEMENT_MODULE);
+        final String moduleName = createClassFromPath(gitChange.getPath()).getSimpleName();
+        module.setAttribute(ATTR_NAME, moduleName);
+        return module;
+    }
+
+    @Override
+    protected boolean whetherToSkipChange(GitChange gitChange) {
+        boolean returnValue = super.whetherToSkipChange(gitChange);
+        if (!gitChange.getPath().startsWith("src/main/java")) {
+            returnValue = true;
+        }
+        else {
+            final Class<?> clazz = createClassFromPath(gitChange.getPath());
+            if (clazz != null) {
+                returnValue |= !ModuleReflectionUtils.isCheckstyleModule(clazz);
+            }
+            else {
+                returnValue = true;
+            }
+        }
+        return returnValue;
+    }
+
+    /**
+     * Creates the class corresponding to the changed file path.
+     * @param path the changed file path
+     * @return the class corresponding to the changed file path
+     */
+    private Class<?> createClassFromPath(String path) {
+        Class<?> returnValue;
+        final String className = path
+                .replace("src/main/java/", "")
+                .replace(".java", "")
+                .replaceAll("/", ".");
+        try {
+            returnValue = Class.forName(className);
+        }
+        catch (ClassNotFoundException ex) {
+            returnValue = null;
+        }
+        return returnValue;
+    }
+}

--- a/src/main/java/com/github/checkstyle/regression/generator/package-info.java
+++ b/src/main/java/com/github/checkstyle/regression/generator/package-info.java
@@ -1,0 +1,23 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2017 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Contains regression test config generators and utility classes.
+ */
+package com.github.checkstyle.regression.generator;

--- a/src/main/java/com/github/checkstyle/regression/git/DiffParser.java
+++ b/src/main/java/com/github/checkstyle/regression/git/DiffParser.java
@@ -1,0 +1,106 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2017 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.github.checkstyle.regression.git;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.lib.ObjectReader;
+import org.eclipse.jgit.lib.Ref;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.revwalk.RevTree;
+import org.eclipse.jgit.revwalk.RevWalk;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+import org.eclipse.jgit.treewalk.AbstractTreeIterator;
+import org.eclipse.jgit.treewalk.CanonicalTreeParser;
+
+/**
+ * Git diff parser.
+ * @author LuoLiangchen
+ */
+public class DiffParser {
+    /** The prefix of branch head commit ref. */
+    private static final String COMMIT_REF_PREFIX = "refs/heads/";
+
+    /** The path of checkstyle repository. */
+    private final String repositoryPath;
+
+    /**
+     * Creates a new {@code DiffParser} instance.
+     * @param repositoryPath the path of checkstyle repository
+     */
+    public DiffParser(String repositoryPath) {
+        this.repositoryPath = repositoryPath;
+    }
+
+    /**
+     * Parses the diff between a given branch and the master.
+     * @param branchName the name of the branch to be compared with master
+     * @return a list of {@code GitChange} to represent the changes
+     * @throws IOException JGit library exception
+     * @throws GitAPIException JGit library exception
+     */
+    public List<GitChange> parse(String branchName) throws IOException, GitAPIException {
+        final File gitDir = new File(repositoryPath + "/.git");
+        try (Repository repository = new FileRepositoryBuilder().setGitDir(gitDir)
+                .readEnvironment().findGitDir().build()) {
+            try (Git git = new Git(repository)) {
+                final AbstractTreeIterator featureTreeParser =
+                        prepareTreeParser(repository, COMMIT_REF_PREFIX + branchName);
+                final AbstractTreeIterator masterTreeParser =
+                        prepareTreeParser(repository, COMMIT_REF_PREFIX + "master");
+                return git.diff()
+                        .setOldTree(masterTreeParser)
+                        .setNewTree(featureTreeParser)
+                        .call()
+                        .stream()
+                        .map(GitChange::new)
+                        .collect(Collectors.toList());
+            }
+        }
+    }
+
+    /**
+     * Creates a tree parser from a commit, to be used by diff command.
+     * @param repository the repository to parse diff
+     * @param ref        the name of the ref to the commit; e.g., "refs/heads/master"
+     * @return the tree parser
+     * @throws IOException JGit library exception
+     */
+    private static AbstractTreeIterator prepareTreeParser(Repository repository, String ref)
+            throws IOException {
+        final Ref head = repository.exactRef(ref);
+        try (RevWalk walk = new RevWalk(repository)) {
+            final RevCommit commit = walk.parseCommit(head.getObjectId());
+            final RevTree tree = walk.parseTree(commit.getTree().getId());
+            final CanonicalTreeParser treeParser = new CanonicalTreeParser();
+            try (ObjectReader reader = repository.newObjectReader()) {
+                treeParser.reset(reader, tree.getId());
+            }
+            walk.dispose();
+            return treeParser;
+        }
+    }
+}

--- a/src/main/java/com/github/checkstyle/regression/git/GitChange.java
+++ b/src/main/java/com/github/checkstyle/regression/git/GitChange.java
@@ -1,0 +1,47 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2017 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.github.checkstyle.regression.git;
+
+import org.eclipse.jgit.diff.DiffEntry;
+
+/**
+ * Represents git changes of a file.
+ * @author LuoLiangchen
+ */
+public class GitChange {
+    /** The path of the changed file. */
+    private final String path;
+
+    /**
+     * Creates a new {@code GitChange} instance from a {@code DiffEntry}.
+     * @param diff the {@code DiffEntry}
+     */
+    GitChange(DiffEntry diff) {
+        path = diff.getNewPath();
+    }
+
+    /**
+     * Gets the path of the changed file.
+     * @return the path of the changed file
+     */
+    public String getPath() {
+        return path;
+    }
+}

--- a/src/main/java/com/github/checkstyle/regression/git/package-info.java
+++ b/src/main/java/com/github/checkstyle/regression/git/package-info.java
@@ -1,0 +1,23 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2017 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Contains git related classes.
+ */
+package com.github.checkstyle.regression.git;

--- a/src/main/java/com/github/checkstyle/regression/package-info.java
+++ b/src/main/java/com/github/checkstyle/regression/package-info.java
@@ -1,0 +1,23 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2017 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Contains main holder and utility classes.
+ */
+package com.github.checkstyle.regression;


### PR DESCRIPTION
I created a maven project.

The `config` folder, `.travis.yml`, `LICENSE`, `pom.xml`, `.gitignore` refer to checkstyle/checkstyle and checkstyle/contribution repo.

Current structure:
- git: Contains git related classes.
  - DiffParser: Git diff parser. Parse the git diff between a specific branch and master, and return a list of GitChange.
  - GitChange: Represents git changes of a file. Currently it only has path info. There would be more details in the future.
- generator: Contains regression test config generators and utility classes.
  - AbstractConfigGenerator: The base class for config generators. Contains the common initialization and generation logic.
  - ConfigGeneratorFactory: Defines a factory API that enables developers to obtain a generator that processes the git changes and generate config XML.
  - DefaultConfigGenerator: The simplest generator implementation using only default options of checks.

`AbstractConfigGenerator` has two important methods: `createModuleElements` and `whetherToSkipChange`. The implementations of generator would override these two.

`DefaultConfigGenerator` is one of the implementation. As we early discussed in my proposal, it is only concerned about the changes of checkstyle module files and generate config with default options.