### PR TITLE
Issue #8: added pmd validation

### DIFF
--- a/config/pmd.xml
+++ b/config/pmd.xml
@@ -1,0 +1,213 @@
+<?xml version="1.0"?>
+<ruleset name="PMD ruleset for Checkstyle"
+        xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0
+         http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+  <description>
+    PMD ruleset for Checkstyle Regression Tool
+  </description>
+  <rule ref="rulesets/java/basic.xml"/>
+  <rule ref="rulesets/java/braces.xml"/>
+  <rule ref="rulesets/java/clone.xml"/>
+  <rule ref="rulesets/java/codesize.xml">
+    <!-- we are using CyclomaticComplexity -->
+    <exclude name="ModifiedCyclomaticComplexity"/>
+    <!-- we are using CyclomaticComplexity -->
+    <exclude name="StdCyclomaticComplexity"/>
+  </rule>
+
+  <rule ref="rulesets/java/codesize.xml/CyclomaticComplexity">
+    <properties>
+      <property name="showClassesComplexity" value="false"/>
+      <property name="reportLevel" value="11"/>
+    </properties>
+  </rule>
+  <rule ref="rulesets/java/codesize.xml/NPathComplexity" />
+  <rule ref="rulesets/java/codesize.xml/TooManyFields" />
+  <rule ref="rulesets/java/codesize.xml/TooManyMethods" />
+  <rule ref="rulesets/java/codesize.xml/ExcessiveClassLength" />
+  <rule ref="rulesets/java/codesize.xml/ExcessiveMethodLength" />
+
+  <rule ref="rulesets/java/comments.xml">
+    <!-- <exclude name="CommentRequired"/> -->
+    <!-- we use class comments as source for xdoc files, so content is big and that is by design -->
+    <exclude name="CommentSize"/>
+  </rule>
+  <rule ref="rulesets/java/comments.xml/CommentRequired" />
+  <rule ref="rulesets/java/comments.xml/CommentSize">
+    <properties>
+      <!-- we use class comments as source for xdoc files, so content is big and that is by design -->
+      <property name="violationSuppressXPath" value="//ClassOrInterfaceDeclaration | //PackageDeclaration"/>
+      <property name="maxLines" value="8"/>
+      <property name="maxLineLength" value="100"/>
+    </properties>
+  </rule>
+
+  <rule ref="rulesets/java/controversial.xml">
+    <!-- calling super() is completely pointless, no matter if class inherits anything or not; it is meaningful only if you do not call implicit constructor of base class -->
+    <exclude name="CallSuperInConstructor"/>
+    <!-- We reuse Check instances between java files, we need to clear state of class in beginTree() methods -->
+    <exclude name="NullAssignment"/>
+    <!-- it is possible only in functional languages and fanatically-pristine code, without additional option that are done at ReturnCountExtendedCheck it is not good rule -->
+    <exclude name="OnlyOneReturn"/>
+    <!-- opposite to UnnecessaryConstructor -->
+    <exclude name="AtLeastOneConstructor"/>
+    <!-- that rule is too buggy, too much false positives-->
+    <exclude name="DataflowAnomalyAnalysis"/>
+    <!-- turning local variables to fields create design problems and extend scope of variable -->
+    <exclude name="AvoidFinalLocalVariable"/>
+    <!-- conflicts with names that does not mean in/out -->
+    <exclude name="AvoidPrefixingMethodParameters"/>
+    <!-- that is not practical, no options to allow some magic numbers, we will use our implementation -->
+    <exclude name="AvoidLiteralsInIfCondition"/>
+    <!-- Checkstyle is not thread safe -->
+    <exclude name="UseConcurrentHashMap"/>
+  </rule>
+  <rule ref="rulesets/java/controversial.xml/AvoidUsingShortType">
+    <properties>
+      <!-- that class integrates checkstyle and antlr that is why it has a lot of imports -->
+      <property name="violationSuppressXPath" value="//ClassOrInterfaceDeclaration[@Image='AutomaticBean']"/>
+    </properties>
+  </rule>
+  <rule ref="rulesets/java/coupling.xml">
+    <!-- produce too much violations, suppressed till we figure out how useful that metrics-->
+    <exclude name="LawOfDemeter"/>
+    <!-- this rule is for managing import, we have special Check for that -->
+    <exclude name="LoosePackageCoupling"/>
+  </rule>
+  <rule ref="rulesets/java/coupling.xml/ExcessiveImports" />
+  <rule ref="rulesets/java/coupling.xml/CouplingBetweenObjects" />
+
+  <rule ref="rulesets/java/design.xml">
+    <!-- extra final modifier does not make code more secure in that cases-->
+    <exclude name="ImmutableField"/>
+    <!-- this rule does not have any option, unreasonable to use -->
+    <exclude name="MissingBreakInSwitch"/>
+    <!-- we need compare by ref as Tree structure is immutable, we can easily rely on refs -->
+    <exclude name="CompareObjectsWithEquals"/>
+    <!-- we will use our own declaration order logic -->
+    <exclude name="FieldDeclarationsShouldBeAtStartOfClass"/>
+    <!-- too much alarms of Checks, we will never move logic out of Check, each Check is independent logic container -->
+    <exclude name="GodClass"/>
+  </rule>
+
+  <rule ref="rulesets/java/design.xml/ConfusingTernary" />
+  <rule ref="rulesets/java/design.xml/AccessorClassGeneration" />
+  <rule ref="rulesets/java/design.xml/PreserveStackTrace" />
+  <rule ref="rulesets/java/design.xml/EmptyMethodInAbstractClassShouldBeAbstract" />
+  <rule ref="rulesets/java/design.xml/AbstractClassWithoutAnyMethod" />
+
+  <rule ref="rulesets/java/design.xml/AvoidDeeplyNestedIfStmts">
+    <properties>
+      <!-- default is 3 but we try to use single point of exit from method and that require extra IFs -->
+      <property name="problemDepth" value="4"/>
+    </properties>
+  </rule>
+
+  <rule ref="rulesets/java/empty.xml"/>
+  <rule ref="rulesets/java/empty.xml/EmptyCatchBlock">
+    <properties>
+      <property name="allowCommentedBlocks" value="true"/>
+    </properties>
+  </rule>
+
+  <rule ref="rulesets/java/finalizers.xml"/>
+  <rule ref="rulesets/java/imports.xml"/>
+  <rule ref="rulesets/java/javabeans.xml">
+    <!-- too many false-positives -->
+    <exclude name="BeanMembersShouldSerialize"/>
+  </rule>
+  <rule ref="rulesets/java/junit.xml"/>
+  <rule ref="rulesets/java/logging-jakarta-commons.xml"/>
+
+  <rule ref="rulesets/java/logging-java.xml"/>
+  <rule ref="rulesets/java/logging-java.xml/SystemPrintln">
+    <properties>
+      <!-- it is ok to use println in CLI class -->
+      <property name="violationSuppressXPath" value="//ClassOrInterfaceDeclaration[@Image='Main']"/>
+    </properties>
+  </rule>
+  <rule ref="rulesets/java/logging-java.xml/AvoidPrintStackTrace">
+    <properties>
+      <!-- it is ok to use print stack trace in CLI class -->
+      <property name="violationSuppressXPath" value="//ClassOrInterfaceDeclaration[@Image='Main']"/>
+    </properties>
+  </rule>
+
+  <rule ref="rulesets/java/migrating.xml"/>
+
+  <rule ref="rulesets/java/naming.xml">
+    <!-- we use CheckstyleCustomShortVariable, to control lenght (will be fixed in PMD 5.4) and skip Override methods -->
+    <exclude name="ShortVariable"/>
+  </rule>
+  <rule name="CheckstyleCustomShortVariable"
+      message="Avoid variables with short names that shorter than 2 symbols: {0}"
+      language="java"
+      class="net.sourceforge.pmd.lang.rule.XPathRule"
+      externalInfoUrl="">
+    <description>
+      Fields, local variables, or parameter names that are very short are not helpful to the reader.
+    </description>
+    <priority>3</priority>
+    <properties>
+      <property name="xpath">
+        <value>
+          <![CDATA[
+ //VariableDeclaratorId[string-length(@Image) < 2]
+ [not(ancestor::ForInit)]
+ [not(../../VariableDeclarator and ../../../LocalVariableDeclaration and ../../../../ForStatement)]
+ [not((ancestor::FormalParameter) and (ancestor::TryStatement))]
+ [not(ancestor::ClassOrInterfaceDeclaration[//MarkerAnnotation/Name[pmd-java:typeof(@Image, 'java.lang.Override', 'Override')]])]
+           ]]>
+        </value>
+      </property>
+    </properties>
+  </rule>
+  <rule ref="rulesets/java/naming.xml/AbstractNaming" />
+  <rule ref="rulesets/java/naming.xml/LongVariable">
+    <properties>
+      <!-- nothing bad in long and descriptive variable names if only they fit line, but still keep it reasonable -->
+      <property name="minimum" value="45"/>
+    </properties>
+  </rule>
+  <rule ref="rulesets/java/naming.xml/ShortClassName">
+    <properties>
+      <!-- Main is good name for class containing main method -->
+      <property name="violationSuppressXPath" value="//ClassOrInterfaceDeclaration[@Image='Main']"/>
+    </properties>
+  </rule>
+
+  <rule ref="rulesets/java/optimizations.xml">
+    <!--produces more false-positives than real problems-->
+    <exclude name="AvoidInstantiatingObjectsInLoops"/>
+    <!--pollutes code with modifiers-->
+    <exclude name="LocalVariableCouldBeFinal"/>
+    <!--pollutes code with modifiers-->
+    <exclude name="MethodArgumentCouldBeFinal"/>
+    <!--not configurable, decreases readability-->
+    <exclude name="UseStringBufferForStringAppends"/>
+  </rule>
+  <rule ref="rulesets/java/strictexception.xml/AvoidCatchingGenericException" />
+  <rule ref="rulesets/java/strictexception.xml/AvoidThrowingRawExceptionTypes" />
+  <rule ref="rulesets/java/strictexception.xml/SignatureDeclareThrowsException">
+    <properties>
+      <!-- it is ok to throw exception in top level class -->
+      <property name="violationSuppressXPath" value="//ClassOrInterfaceDeclaration[@Image='Main'] and //MethodDeclaration[@Name='main']"/>
+    </properties>
+  </rule>
+
+  <rule ref="rulesets/java/strings.xml"/>
+  <rule ref="rulesets/java/strings.xml/AvoidDuplicateLiterals">
+    <properties>
+      <!-- Annotations like '@SuppressWarnings' don't need to be checked, it is better to keep their strings
+           connected to the annotation instead of separating. -->
+      <property name="skipAnnotations" value="true"/>
+    </properties>
+  </rule>
+  <rule ref="rulesets/java/sunsecure.xml/MethodReturnsInternalArray" />
+  <rule ref="rulesets/java/typeresolution.xml"/>
+  <rule ref="rulesets/java/unnecessary.xml"/>
+  <rule ref="rulesets/java/unusedcode.xml"/>
+
+</ruleset>

--- a/pom.xml
+++ b/pom.xml
@@ -12,8 +12,11 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <checkstyle.version>7.8.1</checkstyle.version>
         <maven.plugin.checkstyle.version>2.17</maven.plugin.checkstyle.version>
+        <maven.findbugs.plugin.version>3.0.4</maven.findbugs.plugin.version>
+        <maven.pmd.plugin.version>3.7</maven.pmd.plugin.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <java.version>1.8</java.version>
     </properties>
 
     <dependencies>
@@ -41,6 +44,27 @@
     </dependencies>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-pmd-plugin</artifactId>
+                    <version>${maven.pmd.plugin.version}</version>
+                    <configuration>
+                        <targetJdk>${java.version}</targetJdk>
+                        <minimumTokens>20</minimumTokens>
+                        <skipEmptyReport>false</skipEmptyReport>
+                        <failOnViolation>true</failOnViolation>
+                        <printFailingErrors>true</printFailingErrors>
+                        <!--<includeTests>true</includeTests> -->
+                        <rulesets>
+                            <ruleset>config/pmd.xml</ruleset>
+                        </rulesets>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -79,6 +103,18 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-pmd-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 
@@ -103,6 +139,19 @@
                     </formats>
                     <check />
                 </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-pmd-plugin</artifactId>
+                <version>${maven.pmd.plugin.version}</version>
+                <reportSets>
+                    <reportSet>
+                        <reports>
+                            <report>pmd</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
             </plugin>
         </plugins>
     </reporting>

--- a/src/main/java/com/github/checkstyle/regression/Main.java
+++ b/src/main/java/com/github/checkstyle/regression/Main.java
@@ -34,5 +34,6 @@ public final class Main {
      * @throws Exception execute failure
      */
     public static void main(String[] args) throws Exception {
+        // empty for now
     }
 }


### PR DESCRIPTION
Issue #8 

Added PMD.
Java version was required for PMD otherwise it failed with: `maven-pmd-plugin:3.7:pmd (pmd) on project regression-tool: Execution pmd of goal org.apache.maven.plugins:maven-pmd-plugin:3.7:pmd failed: org.apache.maven.reporting.MavenReportException: Unsupported targetJdk value '1.8.0_77'. -> [Help 1]`

@Luolc As we proceed with project, we can come to an agreement on suppressing any of these rules.