### PR TITLE
Pull #51: fix write option bug in ConfigGenerator

### DIFF
--- a/src/main/java/com/github/checkstyle/regression/configuration/ConfigGenerator.java
+++ b/src/main/java/com/github/checkstyle/regression/configuration/ConfigGenerator.java
@@ -126,8 +126,9 @@ public final class ConfigGenerator {
     public static File generateConfig(String path, List<ModuleInfo> moduleInfos)
             throws IOException, TransformerException {
         final File file = new File(path);
-        Files.write(file.toPath(), generateConfigText(moduleInfos)
-                .getBytes(Charset.forName("UTF-8")), StandardOpenOption.TRUNCATE_EXISTING);
+        Files.write(
+                file.toPath(), generateConfigText(moduleInfos).getBytes(Charset.forName("UTF-8")),
+                StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
         return file;
     }
 

--- a/src/test/java/com/github/checkstyle/regression/configuration/ConfigGeneratorTest.java
+++ b/src/test/java/com/github/checkstyle/regression/configuration/ConfigGeneratorTest.java
@@ -148,6 +148,16 @@ public class ConfigGeneratorTest {
         assertTrue("Config is not as expected", FileUtils.contentEquals(excepted, actual));
     }
 
+    @Test
+    public void testGenerateConfigToNewFileNoException() throws Exception {
+        final File temp = File.createTempFile("TempNewFile", "");
+        final String path = temp.getPath();
+        // delete the file, to test generating file with mode StandardOpenOption.CREATE
+        temp.delete();
+        final File output = ConfigGenerator.generateConfig(path, Collections.emptyList());
+        outputConfigs.add(output);
+    }
+
     private File generateConfig(List<ModuleInfo> moduleInfos) throws Exception {
         final File temp = File.createTempFile("TestTempConfigOutput", "");
         final String path = temp.getPath();


### PR DESCRIPTION
`TRUNCATE_EXISTING` option is only for there is already a file exiting.
`CREATE` is necessary for nothing there, without is there would be exception raised.
These two could be set together.