### PR TITLE
Issue #77: git: add line changes detection

### DIFF
--- a/config/import-control.xml
+++ b/config/import-control.xml
@@ -49,5 +49,6 @@
 
     <subpackage name="git">
         <allow pkg="org.eclipse.jgit"/>
+        <allow pkg="org.apache.commons.lang"/>
     </subpackage>
 </import-control>

--- a/src/main/java/com/github/checkstyle/regression/data/GitChange.java
+++ b/src/main/java/com/github/checkstyle/regression/data/GitChange.java
@@ -19,6 +19,8 @@
 
 package com.github.checkstyle.regression.data;
 
+import java.util.List;
+
 import org.immutables.value.Value;
 
 /**
@@ -32,4 +34,18 @@ public interface GitChange {
      * @return the path of the changed file
      */
     String path();
+
+    /**
+     * The line numbers of the added changes.
+     * The first line of a file is marked as line zero.
+     * @return the line numbers of the added changes
+     */
+    List<Integer> addedLines();
+
+    /**
+     * The line numbers of the deleted changes.
+     * The first line of a file is marked as line zero.
+     * @return the line numbers of the deleted changes
+     */
+    List<Integer> deletedLines();
 }


### PR DESCRIPTION
#77

In method `parse`, we have to use for-loop instead of `map`, for `convertDiffEntryToGitChange` now throws `IOException`.

Since `IntStream.range` is banned for the cobertura bug, I use apache.common's `IntRange` instead.

I add a comment to ignore `ClassDataAbstractionCoupling`.