### PR TITLE
minor: fix travis build

### DIFF
--- a/.ci/travis/checkstyle_regression_no_exception.sh
+++ b/.ci/travis/checkstyle_regression_no_exception.sh
@@ -24,7 +24,8 @@ git checkout master
 git reset --hard "${MASTER_COMMIT}"
 cd ..
 mvn clean package -Passembly
-java -jar target/regression-tool-1.0-SNAPSHOT-all.jar -r "$CHECKSTYLE_PATH" -p test-branch -t contribution/checkstyle-tester
+cp target/regression-tool-1.0-SNAPSHOT-all.jar .
+java -jar regression-tool-1.0-SNAPSHOT-all.jar -r "$CHECKSTYLE_PATH" -p test-branch -t contribution/checkstyle-tester
 RESULT="$?"
 cat config-test-branch-*.xml
 rm config-test-branch-*.xml


### PR DESCRIPTION
Fixes failure on travis build; diff.groovy requires config to be in the same directory for crosslinked file generation.  Example of failure: https://travis-ci.org/github/checkstyle/regression-tool/jobs/755185633

![image](https://user-images.githubusercontent.com/31252532/105054461-07312480-5a40-11eb-9983-945729cbce90.png)

