### PR TITLE
minor: fix maven instability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,11 @@
                         <artifactId>checkstyle</artifactId>
                         <version>${checkstyle.version}</version>
                     </dependency>
+                    <dependency>
+                        <groupId>com.github.sevntu-checkstyle</groupId>
+                        <artifactId>sevntu-checks</artifactId>
+                        <version>${maven.sevntu.checkstyle.plugin.version}</version>
+                    </dependency>
                 </dependencies>
                 <executions>
                     <execution>
@@ -169,21 +174,6 @@
                             </outputFile>
                         </configuration>
                     </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>${maven.plugin.checkstyle.version}</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>com.puppycrawl.tools</groupId>
-                        <artifactId>checkstyle</artifactId>
-                        <version>${checkstyle.version}</version>
-                    </dependency>
-                </dependencies>
-                <executions>
                     <execution>
                         <id>check_non_main</id>
                         <goals>
@@ -243,26 +233,6 @@
                             </excludes>
                         </configuration>
                     </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>${maven.plugin.checkstyle.version}</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>com.puppycrawl.tools</groupId>
-                        <artifactId>checkstyle</artifactId>
-                        <version>${checkstyle.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>com.github.sevntu-checkstyle</groupId>
-                        <artifactId>sevntu-checks</artifactId>
-                        <version>${maven.sevntu.checkstyle.plugin.version}</version>
-                    </dependency>
-                </dependencies>
-                <executions>
                     <execution>
                         <id>check_sevntu</id>
                         <goals>
@@ -469,7 +439,8 @@
                                         <lineRate>77</lineRate>
                                     </regex>
                                     <regex>
-                                        <pattern>com.github.checkstyle.regression.configuration.ConfigGenerator</pattern>
+                                        <pattern>com.github.checkstyle.regression.configuration.ConfigGenerator
+                                        </pattern>
                                         <branchRate>80</branchRate>
                                         <lineRate>92</lineRate>
                                     </regex>


### PR DESCRIPTION
Fixes instability of maven, identified at https://travis-ci.org/github/checkstyle/regression-tool/jobs/755185633#L228: 

![image](https://user-images.githubusercontent.com/31252532/105054027-8c680980-5a3f-11eb-9d75-74abdd57315e.png)

Problems in stability detected at https://travis-ci.org/github/checkstyle/regression-tool/jobs/754769881#L21143